### PR TITLE
Fix Silent None output, wrong cell and same celll

### DIFF
--- a/pybraille/__init__.py
+++ b/pybraille/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "0.1.0"
 
-from main import convertText, convertFile
+from .main import convertText, convertFile
 
 """
 - convertText

--- a/pybraille/main.py
+++ b/pybraille/main.py
@@ -2,8 +2,8 @@ characterUnicodes = {'a': '\u2801', 'b': '\u2803', 'k': '\u2805', 'l': '\u2807',
 'f': '\u280B', 'm': '\u280D', 's': '\u280E', 'p': '\u280F', 'e': '\u2811', 'h': '\u2813', 'o': '\u2815', 'r': '\u2817',
 'd': '\u2819', 'j': '\u281A', 'g': '\u281B', 'n': '\u281D', 't': '\u281E', 'q': '\u281F', 'u': '\u2825', 'v': '\u2827',
 'x': '\u282D', 'z': '\u2835', 'w': '\u283A', 'y': '\u283D', 'num': '\u283C', 'caps': '\u2820', '.': '\u2832',
-"'": '\u2804', ',': '\u2802', '-': '\u2824', '/': '\u280C', '!' : '\u2816', '?': '\u2826', '$': '\u2832', ':': '\u2812',
-';': '\u2830', '(': '\u2836', ')': '\u2836', ' ': ' ', '1': '\u2801', '2': '\u2803', '3': '\u2809', '4': '\u2819',
+"'": '\u2804', ',': '\u2802', '-': '\u2824', '/': '\u280C', '!' : '\u2816', '?': '\u2826', '$': '\u282B', ':': '\u2812',
+';': '\u2830', '(': '\u2837', ')': '\u283E', ' ': ' ', '1': '\u2801', '2': '\u2803', '3': '\u2809', '4': '\u2819',
 '5': '\u2811', '6': '\u280B', '7': '\u281B', '8': '\u2813', '9': '\u280A', '0': '\u281A'}
 
 numberPunctuations = ['.', ',', '-', '/', '$']
@@ -42,6 +42,9 @@ def convert(textToConvert):
     else:
       if isNumber and character not in numberPunctuations:
         isNumber = False
-    convertedText += characterUnicodes.get(character)
+    cell = characterUnicodes.get(character)
+    if cell is None:
+      continue
+    convertedText += cell
   return convertedText
 

--- a/tests/test_braille.py
+++ b/tests/test_braille.py
@@ -1,7 +1,111 @@
+import pathlib
+import pytest
 from pybraille.main import convertText, convertFile
+
+SAMPLE_TXT = pathlib.Path(__file__).parent / "sample.txt"
+
+# --- convertText: basic ---
 
 def testConvertText():
   assert convertText("hello") == "⠓⠑⠇⠇⠕"
 
+def testEmptyString():
+  assert convertText("") == ""
+
+def testSingleLetter():
+  assert convertText("a") == "⠁"
+
+# --- convertText: uppercase ---
+
+def testUppercaseAddsCapIndicator():
+  # 'A' should be caps indicator + braille 'a'
+  assert convertText("A") == "⠠⠁"
+
+def testMixedCase():
+  # Each uppercase letter gets its own caps indicator
+  assert convertText("Hi") == "⠠⠓⠊"
+
+# --- convertText: numbers ---
+
+def testSingleDigit():
+  # num indicator + braille cell for '1' (same cell as 'a')
+  assert convertText("1") == "⠼⠁"
+
+def testMultiDigitNumber():
+  # num indicator appears only once at the start
+  assert convertText("123") == "⠼⠁⠃⠉"
+
+def testNumberModeResetOnLetter():
+  # After a non-number-punctuation char, number mode resets
+  # so the second digit gets a new num indicator
+  assert convertText("1a2") == "⠼⠁⠁⠼⠃"
+
+def testNumberPunctuationKeepsNumberMode():
+  # Comma inside a number keeps number mode — second digit gets no new num indicator
+  assert convertText("1,2") == "⠼⠁⠂⠃"
+
+# --- convertText: punctuation ---
+
+def testPeriod():
+  assert convertText(".") == "⠲"
+
+def testComma():
+  assert convertText(",") == "⠂"
+
+def testExclamation():
+  assert convertText("!") == "⠖"
+
+def testQuestion():
+  assert convertText("?") == "⠦"
+
+def testOpenParen():
+  assert convertText("(") == "⠷"
+
+def testCloseParen():
+  assert convertText(")") == "⠾"
+
+def testParensDistinct():
+  assert convertText("(") != convertText(")")
+
+def testDollarDistinctFromPeriod():
+  assert convertText("$") != convertText(".")
+
+# --- convertText: escape characters ---
+
+def testNewlinePassthrough():
+  assert convertText("a\nb") == "⠁\n⠃"
+
+def testTabPassthrough():
+  assert convertText("a\tb") == "⠁\t⠃"
+
+# --- convertText: unsupported characters ---
+
+def testUnsupportedCharSkipped():
+  # '@' is not in the mapping — should be silently skipped
+  assert convertText("@") == ""
+
+def testUnsupportedCharMidString():
+  assert convertText("a@b") == "⠁⠃"
+
+# --- convertText: type errors ---
+
+def testNonStringRaisesTypeError():
+  with pytest.raises(TypeError):
+    convertText(123)
+
+def testNoneRaisesTypeError():
+  with pytest.raises(TypeError):
+    convertText(None)
+
+def testListRaisesTypeError():
+  with pytest.raises(TypeError):
+    convertText(["hello"])
+
+# --- convertFile ---
+
 def testConvertFile():
-  assert convertFile("tests/sample.txt") == "⠠⠞⠓⠊⠎ ⠙⠊⠗⠑⠉⠞⠕⠗⠽ ⠉⠕⠝⠞⠁⠊⠝⠎ ⠞⠑⠎⠞ ⠋⠊⠇⠑⠎⠲"
+  assert convertFile(str(SAMPLE_TXT)) == "⠠⠞⠓⠊⠎ ⠙⠊⠗⠑⠉⠞⠕⠗⠽ ⠉⠕⠝⠞⠁⠊⠝⠎ ⠞⠑⠎⠞ ⠋⠊⠇⠑⠎⠲"
+
+def testConvertFileNonStringRaisesTypeError():
+  with pytest.raises(TypeError):
+    convertFile(42)


### PR DESCRIPTION
1. **Fix silent None output for unsupported characters** — `characterUnicodes.get(character)` returns `None` for unknown chars (e.g. `@`, `#`, `%`, `&`, `*`), which concatenates the string `"None"` into output. Skip unknown chars or raise clearly.

2. **Fix `$` mapping to wrong Braille cell** — `$` maps to the same Unicode as `.` (⠲). Assign the correct cell.

3. **Fix `(` and `)` mapping to the same Braille cell** — They have distinct Braille representations; map them separately.